### PR TITLE
Fix when mysql password is empty

### DIFF
--- a/src/Joomlatools/Console/Command/SiteDelete.php
+++ b/src/Joomlatools/Console/Command/SiteDelete.php
@@ -37,7 +37,9 @@ class SiteDelete extends SiteAbstract
 
     public function deleteDatabase(InputInterface $input, OutputInterface $output)
     {
-        $result = `echo 'DROP DATABASE IF EXISTS $this->target_db' | mysql -u{$this->mysql->user} -p{$this->mysql->password}`;
+        $password = empty($this->mysql->password) ? '' : sprintf('-p %', $this->mysql->password);
+        $result = exec(sprintf("echo 'DROP DATABASE IF EXISTS $this->target_db' | mysql -u %s %s", $this->mysql->user, $password));
+
         if (!empty($result)) { // MySQL returned an error
             throw new \RuntimeException(sprintf('Cannot delete database %s. Error: %s', $this->target_db, $result));
         }


### PR DESCRIPTION
When the mysql password is empty, with `-p` mysql keeps asking the password which makes the command interactive.
Also fixed the db credentials in the Joomla config
