### PR TITLE
Made MySQL port configurable

### DIFF
--- a/src/Joomlatools/Console/Command/Database/AbstractDatabase.php
+++ b/src/Joomlatools/Console/Command/Database/AbstractDatabase.php
@@ -39,6 +39,13 @@ abstract class AbstractDatabase extends AbstractSite
             'localhost'
         )
         ->addOption(
+            'mysql-port',
+            'P',
+            InputOption::VALUE_REQUIRED,
+            "MySQL port",
+            3306
+        )
+        ->addOption(
             'mysql_db_prefix',
             null,
             InputOption::VALUE_REQUIRED,
@@ -83,6 +90,7 @@ abstract class AbstractDatabase extends AbstractSite
             'user'     => $credentials[0],
             'password' => $credentials[1],
             'host'     => $input->getOption('mysql-host'),
+            'port'     => (int) $input->getOption('mysql-port'),
             'driver'   => strtolower($input->getOption('mysql-driver'))
         );
 
@@ -94,7 +102,7 @@ abstract class AbstractDatabase extends AbstractSite
     protected function _executeSQL($query)
     {
         $password = empty($this->mysql->password) ? '' : sprintf("--password='%s'", $this->mysql->password);
-        $cmd      = sprintf("echo '$query' | mysql --host=%s --user='%s' %s", $this->mysql->host, $this->mysql->user, $password);
+        $cmd      = sprintf("echo '$query' | mysql --host=%s --port=%u --user='%s' %s", $this->mysql->host, $this->mysql->port, $this->mysql->user, $password);
 
         return exec($cmd);
     }
@@ -104,6 +112,7 @@ abstract class AbstractDatabase extends AbstractSite
         $this->mysql->user     = $this->_ask($input, $output, 'MySQL user', $this->mysql->user, true);
         $this->mysql->password = $this->_ask($input, $output, 'MySQL password', $this->mysql->password, true, true);
         $this->mysql->host     = $this->_ask($input, $output, 'MySQL host', $this->mysql->host, true);
+        $this->mysql->port     = (int) $this->_ask($input, $output, 'MySQL port', $this->mysql->port, true);
         $this->mysql->driver   = $this->_ask($input, $output, 'MySQL driver', array('mysqli', 'mysql'), true);
 
         $output->writeln('Choose the database name. We will attempt to create it if it does not exist.');
@@ -111,6 +120,7 @@ abstract class AbstractDatabase extends AbstractSite
 
         $input->setOption('mysql-login', $this->mysql->user . ':' . $this->mysql->password);
         $input->setOption('mysql-host', $this->mysql->host);
+        $input->setOption('mysql-port', $this->mysql->port);
         $input->setOption('mysql-database', $this->target_db);
         $input->setOption('mysql-driver', $this->mysql->driver);
     }

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -101,7 +101,7 @@ class Install extends AbstractDatabase
             file_put_contents($tmp, $contents);
 
             $password = empty($this->mysql->password) ? '' : sprintf("-p'%s'", $this->mysql->password);
-            $result = exec(sprintf("mysql --host=%s --user='%s' %s %s < %s", $this->mysql->host, $this->mysql->user, $password, $this->target_db, $tmp));
+            $result = exec(sprintf("mysql --host=%s --port=%u --user='%s' %s %s < %s", $this->mysql->host, $this->mysql->port, $this->mysql->user, $password, $this->target_db, $tmp));
 
             unlink($tmp);
 

--- a/src/Joomlatools/Console/Command/Site/Configure.php
+++ b/src/Joomlatools/Console/Command/Site/Configure.php
@@ -122,7 +122,7 @@ class Configure extends AbstractDatabase
             'db'        => $this->target_db,
             'user'      => $this->mysql->user,
             'password'  => $this->mysql->password,
-            'host'      => $this->mysql->host,
+            'host'      => $this->mysql->host.':'.$this->mysql->port,
             'dbprefix'  => 'j_',
             'dbtype'    => $this->mysql->driver,
 
@@ -170,7 +170,7 @@ class Configure extends AbstractDatabase
             'JOOMLA_DB_NAME' => $this->target_db,
             'JOOMLA_DB_USER' => $this->mysql->user,
             'JOOMLA_DB_PASS' => $this->mysql->password,
-            'JOOMLA_DB_HOST' => $this->mysql->host,
+            'JOOMLA_DB_HOST' => $this->mysql->host.':'.$this->mysql->port,
             'JOOMLA_DB_TYPE' => $this->mysql->driver,
 
             'JOOMLA_LOG_PATH' => $this->_default_values['log_path'],

--- a/src/Joomlatools/Console/Command/Site/Create.php
+++ b/src/Joomlatools/Console/Command/Site/Create.php
@@ -159,7 +159,7 @@ EOF
                 '--www'  => $this->www
             );
 
-            $optionalArgs = array('sample-data', 'symlink', 'projects-dir', 'interactive', 'mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-database');
+            $optionalArgs = array('sample-data', 'symlink', 'projects-dir', 'interactive', 'mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-port', 'mysql-database');
             foreach ($optionalArgs as $optionalArg)
             {
                 $value = $input->getOption($optionalArg);

--- a/src/Joomlatools/Console/Command/Site/Delete.php
+++ b/src/Joomlatools/Console/Command/Site/Delete.php
@@ -76,7 +76,7 @@ class Delete extends Database\AbstractDatabase
             'site' => $this->site
         );
 
-        $optionalArgs = array('mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-database');
+        $optionalArgs = array('mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-port', 'mysql-database');
         foreach ($optionalArgs as $optionalArg)
         {
             $value = $input->getOption($optionalArg);

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -125,7 +125,7 @@ class Install extends Database\AbstractDatabase
             '--www'  => $this->www
         );
 
-        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-database');
+        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-port', 'mysql-database');
         foreach ($optionalArgs as $optionalArg)
         {
             $value = $input->getOption($optionalArg);
@@ -150,7 +150,7 @@ class Install extends Database\AbstractDatabase
             '--www'  => $this->www
         );
 
-        $optionalArgs = array('overwrite', 'mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-database', 'mysql-driver', 'interactive');
+        $optionalArgs = array('overwrite', 'mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'mysql-driver', 'interactive');
         foreach ($optionalArgs as $optionalArg)
         {
             $value = $input->getOption($optionalArg);
@@ -244,6 +244,6 @@ class Install extends Database\AbstractDatabase
         $sql = escapeshellarg($sql);
 
         $password = empty($this->mysql->password) ? '' : sprintf("-p'%s'", $this->mysql->password);
-        exec(sprintf("mysql --host=%s -u'%s' %s %s -e %s", $this->mysql->host, $this->mysql->user, $password, $this->target_db, $sql));
+        exec(sprintf("mysql --host=%s --port=%u -u'%s' %s %s -e %s", $this->mysql->host, $this->mysql->port, $this->mysql->user, $password, $this->target_db, $sql));
     }
 }


### PR DESCRIPTION
Made the MySQL port configurable through the command-line options `--mysql-port` or `-P`.

Also see the proposed modification to the documentation in this other PR: https://github.com/joomlatools/developer.joomlatools.com/pull/77