### PR TITLE
Windows console, fix problem with site:create

### DIFF
--- a/src/Joomlatools/Console/Command/Versions.php
+++ b/src/Joomlatools/Console/Command/Versions.php
@@ -132,7 +132,7 @@ class Versions extends Command
             unlink(self::$file);
         }
 
-        $cmd = "git ls-remote $this->repository | grep -E 'refs/(tags|heads)' | grep -v '{}'";
+        $cmd = "git ls-remote $this->repository | grep -E \"refs/(tags|heads)\" | grep -v '{}'";
         exec($cmd, $refs, $returnVal);
 
         if ($returnVal != 0) {


### PR DESCRIPTION
I had fatal error while creating new website (see screen) and spent some time to find problem.
This command works fine on Debian but win7 (Git Bush or cmd.exe) cannot parse command correctly.

![image](https://cloud.githubusercontent.com/assets/1118678/11531213/639264d2-9925-11e5-804e-637ae450ef0b.png)
