### PR TITLE
Allow version 'none' to pass branch check'

### DIFF
--- a/src/Joomlatools/Console/Command/Site/Download.php
+++ b/src/Joomlatools/Console/Command/Site/Download.php
@@ -156,7 +156,7 @@ class Download extends AbstractSite
             }
         }
 
-        if (!$this->versions->isBranch($result))
+        if (!$this->versions->isBranch($result) && $version != 'none')
         {
             $isTag = $this->versions->isTag($result);
 


### PR DESCRIPTION
I was getting
                                                                                                           
```
  [RuntimeException]                                                                                       
  Failed to find tag or branch "none". Please refresh the version list first: `joomla versions --refresh` 
```
When I tried to create a site using ```--release=none```.  I'm not sure if this was the correct way to fix it or not, but it's working for me now.