### PR TITLE
Add the --all flag to composer show

### DIFF
--- a/src/Joomlatools/Console/Command/Plugin/Install.php
+++ b/src/Joomlatools/Console/Command/Plugin/Install.php
@@ -63,7 +63,7 @@ EOF
         }
         else list($name, $version) = explode(':', $package);
 
-        exec("composer show $name $version 2>&1", $result, $code);
+        exec("composer show --all $name $version 2>&1", $result, $code);
 
         if ($code === 1)
         {


### PR DESCRIPTION
Without this flag Composer 1.0 will break if it can't find a composer.json
manifest in the current working directory.