### PR TITLE
Fix autoload path for custom composer vendor-dir

### DIFF
--- a/bin/joomla
+++ b/bin/joomla
@@ -6,11 +6,19 @@
  * @link		http://github.com/joomlatools/joomlatools-console for the canonical source repository
  */
 
-$autoload = __DIR__.'/../vendor/autoload.php';
-if(is_file($autoload)) {
-    require $autoload;
-} else {
-   require __DIR__.'/../../../../vendor/autoload.php';
+$autoloadPaths = array(
+    __DIR__ . '/../../autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/vendor/autoload.php'
+);
+
+foreach ($autoloadPaths as $autoload) {
+    if (file_exists($autoload)) {
+        require_once $autoload;
+        break;
+    }
 }
 
 $application = new Joomlatools\Console\Application();


### PR DESCRIPTION
Hi,

I have to config my `composer.json` like that
```json
    "config"            : {
        "bin-dir" : "../../bin",
        "vendor-dir" : "libraries",
   }
```
And it's located here <MY_PROJECT_ROOT>/src/cck/composer.json
My binaries here <MY_PROJECT_ROOT>/bin

And than a I tried to call joomlatools, fatal error apperied

```
$ ./bin/joomla

Warning: require(<MY_PROJECT_ROOT>/src/cck/libraries/joomlatools/console/bin/../../../../vendor/autoload.php): failed to open stream: No such file or directory in <MY_PROJECT_ROOT>/src/cck/libraries/joomlatools/console/bin/joomla on line 13

Fatal error: require(): Failed opening required '<MY_PROJECT_ROOT>/src/cck/libraries/joomlatools/console/bin/../../../../vendor/autoload.php' (include_path='.') in <MY_PROJECT_ROOT>/src/cck/libraries/joomlatools/console/bin/joomla on line 13
```

I think you should remove hardcode `vendor` and get location form config or accept my pull request

For example, PHPUnit works fine with my config and with default vendor-dir
https://github.com/sebastianbergmann/phpunit/blob/master/phpunit#L25

Now I just create symlink vendor -> libraries

Thanks and best regards, Denis.
