### PR TITLE
(Multiple) Normalize cache dir. Add box.json. Bugfix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /bin/.files/cache
+/bin/joomla.phar

--- a/bin/.files/joomla3.users.sql
+++ b/bin/.files/joomla3.users.sql
@@ -1,3 +1,5 @@
+SET sql_mode="";
+
 INSERT INTO `j_users` (`id`, `name`, `username`, `email`, `password`, `block`, `sendEmail`, `registerDate`, `lastvisitDate`, `activation`, `params`, `lastResetTime`, `resetCount`)
 VALUES
 	(951, 'Super User', 'admin', 'admin@example.com', '871b1a6d54b378b5547a945ea1a8bd18:3UgsAngDFq7D0FRmyiWey4qgV8n5PpEJ', 0, 1, '2013-07-24 09:07:43', '2014-01-07 11:18:12', '0', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', '0000-00-00 00:00:00', 0),

--- a/box.json
+++ b/box.json
@@ -1,0 +1,28 @@
+{
+    "chmod": "0755",
+    "directories": [
+        "src"
+    ],
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": [
+              "phpunit",
+              "Tests", "Test", "tests", "test"
+            ],
+            "in": "vendor"
+        },
+        {
+            "name": "*",
+            "exclude": [
+              "cache"
+            ],
+            "in": "bin/.files"
+        }
+
+    ],
+    "git-version": "package_version",
+    "main": "bin/joomla",
+    "output": "bin/joomla.phar",
+    "stub": true
+}

--- a/src/Joomlatools/Console/Application.php
+++ b/src/Joomlatools/Console/Application.php
@@ -250,4 +250,37 @@ class Application extends \Symfony\Component\Console\Application
             }
         }
     }
+
+    /**
+     * Determine the location where joomlatools-console static data files.
+     *
+     * @return string
+     */
+    public function getDataDir()
+    {
+        return dirname(dirname(dirname(__DIR__))) . '/bin/.files';
+    }
+
+    /**
+     * Determine the location where joomlatools-console can store cache files.
+     *
+     * @return string Directory path. Ex: "/home/myuser/.cache/joomlatools-console".
+     */
+    public function getCacheDir()
+    {
+        $home = strpos(PHP_OS, 'WIN') !== FALSE ? getenv('USERPROFILE') : getenv('HOME');
+        $dataDir = "$home/.cache/joomlatools-console";
+        foreach (array(dirname($dataDir), $dataDir) as $dir) {
+            if (!file_exists($dir))
+            {
+                mkdir($dir);
+            }
+            if (!is_dir($dir) || !is_writable($dir))
+            {
+                throw new \RuntimeException("Failed to find or initialize data dir ($dir)");
+            }
+        }
+        return $dataDir;
+    }
+
 }

--- a/src/Joomlatools/Console/Application.php
+++ b/src/Joomlatools/Console/Application.php
@@ -271,9 +271,14 @@ class Application extends \Symfony\Component\Console\Application
     /**
      * Determine the location where joomlatools-console can store cache files.
      *
-     * @return string Directory path. Ex: "/home/myuser/.cache/joomlatools-console".
+     * @param string|NULL $item
+     *    An optional item to lookup within the cache. Ex: "widgets.json"
+     * @return string
+     *    Directory path.
+     *    Ex: "/home/myuser/.cache/joomlatools-console"
+     *    Ex: "/home/myuser/.cache/joomlatools-console/widgets.json"
      */
-    public function getCacheDir()
+    public function getCachePath($item = NULL)
     {
         $home = strpos(PHP_OS, 'WIN') !== FALSE ? getenv('USERPROFILE') : getenv('HOME');
         $dataDir = "$home/.cache/joomlatools-console";
@@ -287,7 +292,7 @@ class Application extends \Symfony\Component\Console\Application
                 throw new \RuntimeException("Failed to find or initialize data dir ($dir)");
             }
         }
-        return $dataDir;
+        return ($item === NULL) ? $dataDir : $dataDir . '/' . $item;
     }
 
 }

--- a/src/Joomlatools/Console/Application.php
+++ b/src/Joomlatools/Console/Application.php
@@ -254,11 +254,18 @@ class Application extends \Symfony\Component\Console\Application
     /**
      * Determine the location where joomlatools-console static data files.
      *
+     * @param string|NULL $item
+     *    An optional item to lookup within the cache. Ex: "widgets.json"
      * @return string
      */
-    public function getDataDir()
+    public function getDataPath($item = NULL)
     {
-        return dirname(dirname(dirname(__DIR__))) . '/bin/.files';
+        // This doesn't need to be limited to a single folder. For example,
+        // when loading `joomla3.users.sql`, one could do a prioritized
+        // search -- eg '~/.joomlatools-console' then '/etc/joomlatools-console'
+        // then '/usr/share/joomlatools-console'
+        $dir = dirname(dirname(dirname(__DIR__))) . '/bin/.files';
+        return ($item === NULL) ? $dir : $dir . '/' . $item;
     }
 
     /**

--- a/src/Joomlatools/Console/Command/Cache/AbstractCache.php
+++ b/src/Joomlatools/Console/Command/Cache/AbstractCache.php
@@ -114,7 +114,7 @@ abstract class AbstractCache extends AbstractSite
 
     protected function _createTemporaryScript($task, $hash, $client = 0, array $group = array())
     {
-        $template   = realpath(__DIR__.'/../../../../../bin/.files/console-cache.php-tpl');
+        $template   = $this->getApplication()->getDataDir() . '/console-cache.php-tpl';
         $autoloader = realpath(__DIR__.'/../../../../../vendor/autoload.php');
 
         $contents = file_get_contents($template);

--- a/src/Joomlatools/Console/Command/Cache/AbstractCache.php
+++ b/src/Joomlatools/Console/Command/Cache/AbstractCache.php
@@ -114,7 +114,7 @@ abstract class AbstractCache extends AbstractSite
 
     protected function _createTemporaryScript($task, $hash, $client = 0, array $group = array())
     {
-        $template   = $this->getApplication()->getDataDir() . '/console-cache.php-tpl';
+        $template   = $this->getApplication()->getDataPath('console-cache.php-tpl');
         $autoloader = realpath(__DIR__.'/../../../../../vendor/autoload.php');
 
         $contents = file_get_contents($template);

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -170,7 +170,7 @@ class Install extends AbstractDatabase
                 $users = 'joomla2.users.sql';
             }
 
-            $imports[] = self::$files.'/'.$users;
+            $imports[] = $this->getApplication()->getDataDir().'/'.$users;
         }
 
         foreach ($imports as $import)

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -170,7 +170,7 @@ class Install extends AbstractDatabase
                 $users = 'joomla2.users.sql';
             }
 
-            $imports[] = $this->getApplication()->getDataDir().'/'.$users;
+            $imports[] = $this->getApplication()->getDataPath($users);
         }
 
         foreach ($imports as $import)

--- a/src/Joomlatools/Console/Command/Site/AbstractSite.php
+++ b/src/Joomlatools/Console/Command/Site/AbstractSite.php
@@ -22,14 +22,8 @@ abstract class AbstractSite extends Command
 
     protected $target_dir;
 
-    protected static $files;
-
     protected function configure()
     {
-        if (empty(self::$files)) {
-            self::$files = realpath(__DIR__.'/../../../../../bin/.files');
-        }
-
         $this->addArgument(
             'site',
             InputArgument::REQUIRED,

--- a/src/Joomlatools/Console/Command/Site/Create.php
+++ b/src/Joomlatools/Console/Command/Site/Create.php
@@ -168,7 +168,7 @@ EOF
                 }
             }
 
-            $command = new Install();
+            $command = $this->getApplication()->get('site:install');
             $command->setApplication($this->getApplication());
             $command->run(new ArrayInput($arguments), $output);
         }
@@ -196,7 +196,7 @@ EOF
             $arguments['--repo'] = $repo;
         }
 
-        $command = new Download();
+        $command = $this->getApplication()->get('site:download');
         $command->run(new ArrayInput($arguments), $output);
     }
 
@@ -212,7 +212,7 @@ EOF
             '--ssl-port'    => $input->getOption('ssl-port')
         ));
 
-        $command = new Vhost\Create();
+        $command = $this->getApplication()->get('vhost:create');
         $command->run($command_input, $output);
     }
 }

--- a/src/Joomlatools/Console/Command/Site/Delete.php
+++ b/src/Joomlatools/Console/Command/Site/Delete.php
@@ -85,7 +85,7 @@ class Delete extends Database\AbstractDatabase
             }
         }
 
-        $command = new Database\Drop();
+        $command = $this->getApplication()->get('database:drop');
         $command->run(new ArrayInput($arguments), $output);
     }
 
@@ -100,7 +100,7 @@ class Delete extends Database\AbstractDatabase
             'site' => $this->site
         ));
 
-        $command = new Vhost\Remove();
+        $command = $this->getApplication()->get('vhost:remove');
         $command->run($command_input, $output);
     }
 }

--- a/src/Joomlatools/Console/Command/Site/Download.php
+++ b/src/Joomlatools/Console/Command/Site/Download.php
@@ -71,7 +71,7 @@ class Download extends AbstractSite
 
         $this->check($input, $output);
 
-        $this->versions = new Versions();
+        $this->versions = $this->getApplication()->get('versions');;
 
         if ($input->getOption('repo')) {
             $this->versions->setRepository($input->getOption('repo'));

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -125,7 +125,7 @@ class Install extends Database\AbstractDatabase
             '--www'  => $this->www
         );
 
-        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-port', 'mysql-database');
+        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'skip-exists-check');
         foreach ($optionalArgs as $optionalArg)
         {
             $value = $input->getOption($optionalArg);

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -227,7 +227,7 @@ class Install extends Database\AbstractDatabase
             return;
         }
 
-        $filename = realpath($this->getApplication()->getCacheDir()).'/'.basename($url);
+        $filename = $this->getApplication()->getCachePath(basename($url));
         if(!file_exists($filename))
         {
             $bytes = file_put_contents($filename, fopen($url, 'r'));

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -120,7 +120,7 @@ class Install extends Database\AbstractDatabase
     public function importdb(InputInterface $input, OutputInterface $output)
     {
         $arguments = array(
-            'site:database:install',
+            'database:install',
             'site'   => $this->site,
             '--www'  => $this->www
         );
@@ -138,7 +138,7 @@ class Install extends Database\AbstractDatabase
             $arguments['--skip-exists-check'] = true;
         }
 
-        $command = new Database\Install();
+        $command = $this->getApplication()->get('database:install');
         $command->run(new ArrayInput($arguments), $output);
     }
 
@@ -159,8 +159,7 @@ class Install extends Database\AbstractDatabase
             }
         }
 
-        $command = new Configure();
-        $command->setApplication($this->getApplication());
+        $command = $this->getApplication()->get('site:configure');
         $command->skipDatabasePrompt();
         $command->run(new ArrayInput($arguments), $output);
     }

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -228,7 +228,7 @@ class Install extends Database\AbstractDatabase
             return;
         }
 
-        $filename = self::$files.'/cache/'.basename($url);
+        $filename = realpath($this->getApplication()->getCacheDir()).'/'.basename($url);
         if(!file_exists($filename))
         {
             $bytes = file_put_contents($filename, fopen($url, 'r'));

--- a/src/Joomlatools/Console/Command/Versions.php
+++ b/src/Joomlatools/Console/Command/Versions.php
@@ -231,7 +231,6 @@ class Versions extends Command
      * @return string
      */
     protected function getVersionsFile() {
-        return realpath($this->getApplication()->getCacheDir())
-        . '/' . md5($this->repository) . '/.versions';
+        return $this->getApplication()->getCachePath(md5($this->repository) . '/.versions');
     }
 }

--- a/src/Joomlatools/Console/Command/Vhost/Create.php
+++ b/src/Joomlatools/Console/Command/Vhost/Create.php
@@ -70,10 +70,9 @@ class Create extends AbstractSite
         {
             $site = $input->getArgument('site');
             $port = $input->getOption('http-port');
-            $path = $this->getApplication()->getDataDir() . '/';
             $tmp  = '/tmp/vhost.tmp';
 
-            $template     = file_get_contents($path.'/vhost.conf');
+            $template     = file_get_contents($this->getApplication()->getDataPath('vhost.conf'));
             $documentroot = Util::isPlatform($this->target_dir) ? $this->target_dir . '/web/' : $this->target_dir;
 
             file_put_contents($tmp, sprintf($template, $site, $documentroot, $port));
@@ -86,7 +85,7 @@ class Create extends AbstractSite
 
                 if (file_exists($ssl_crt) && file_exists($ssl_key))
                 {
-                    $template = "\n\n" . file_get_contents($path.'/vhost.ssl.conf');
+                    $template = "\n\n" . file_get_contents($this->getApplication()->getDataPath('vhost.ssl.conf'));
                     file_put_contents($tmp, sprintf($template, $site, $documentroot, $ssl_port, $ssl_crt, $ssl_key), FILE_APPEND);
                 }
                 else $output->writeln('<comment>SSL was not enabled for the site. One or more certificate files are missing.</comment>');

--- a/src/Joomlatools/Console/Command/Vhost/Create.php
+++ b/src/Joomlatools/Console/Command/Vhost/Create.php
@@ -70,7 +70,7 @@ class Create extends AbstractSite
         {
             $site = $input->getArgument('site');
             $port = $input->getOption('http-port');
-            $path = realpath(__DIR__.'/../../../../../bin/.files/');
+            $path = $this->getApplication()->getDataDir() . '/';
             $tmp  = '/tmp/vhost.tmp';
 
             $template     = file_get_contents($path.'/vhost.conf');


### PR DESCRIPTION
## Background

I work with a project that relies on a bunch of CLI tools. Unfortunately, as you add a large number of tools using `composer require`, you increase the odds of a hitting a version conflict. (Ex: One tool uses Symfony Console 2.x; another uses 3.x.) As both publisher and user, I've found it quite convenient to package PHP CLI tools as statically-linked PHAR executables -- different versions can coexist peacefully. For Linux/OSX users, installation instructions are pretty simple and easily adapted to user preferences (e.g. `/usr/local/bin` vs `~/bin`). Ex:

```
sudo curl -LsS https://download.civicrm.org/civix/civix.phar -o /usr/local/bin/civix
sudo chmod +x /usr/local/bin/civix
```

(As a bit of anecdata... `drush`, `phpunit`, and `wp-cli` now advertise PHAR as their main distribution channel.)

I offer all of this as background. `PHAR` may or may not be a good distribution channel for typical users of  `joomlatools-console` -- you can judge that better than me. However, most of the changes should be useful regardless of your main distribution channel.
## Changes

`1.` Storing the cache directory in the source-tree is problematic for CLI tools. In the specific case of PHAR, the source-tree becomes read-only at run-time. More generally, mainstream distributors like Debian/Fedora/etal require a clean separation between binaries and data.

Which leads to the main change here: replace all the `__DIR__/../../../../bin/.files/` stuff with a centralized `getDataDir()` that points to `~/.joomlatools-console`.

Using a folder like `~/.joomlatools-console` is useful because you know the user will have write-permissions (regardless of how the tool was installed).

`2`. Building a PHAR is pretty simple with https://github.com/box-project/box2 and a small `box.json` file, e.g.

```
git clone https://github.com/joomlatools/joomlatools-console
cd joomlatools-console
composer install
php -dphar.readonly=0 /usr/local/bin/box build
ls -l bin/joomla.phar
```

`3`. There's an unrelated fix for `site:install` in 4f56c92. We can cherry-pick/resubmit if that's useful, but I needed a combined branch for personal use.
