### PR TITLE
Replace CLI mysql commands with PDO

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "evista/joomlatools/console",
+    "name": "joomlatools/console",
     "type": "project",
     "license": "MPLv2",
     "description": "This command-line script helps to ease the management of Joomla sites in your development environment.",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "joomlatools/console",
+    "name": "evista/joomlatools/console",
     "type": "project",
     "license": "MPLv2",
     "description": "This command-line script helps to ease the management of Joomla sites in your development environment.",

--- a/src/Joomlatools/Console/Command/Database/AbstractDatabase.php
+++ b/src/Joomlatools/Console/Command/Database/AbstractDatabase.php
@@ -119,15 +119,15 @@ abstract class AbstractDatabase extends AbstractSite
         try {
             $db->exec($query);
         } catch (\PDOException $ex) {
-            throw new \RuntimeException(sprintf('Database query failed: error: "%s" "%s"',$ex->getMessage(), $query));
+            throw new \RuntimeException(sprintf('Database query failed: error: "%s" "%s"', $ex->getMessage(), $query));
         }
     }
 
-    private function dbConnection() {
+    private function dbConnection()
+    {
         if (! $this->pdoDB) {
             $password = empty($this->mysql->password) || $this->mysql->password == 'root' ? '' :  $this->mysql->password;
             $connectionString = "mysql:host={$this->mysql->host}:{$this->mysql->port};dbname={$this->target_db};charset=utf8mb4";
-            var_dump($connectionString, $this->mysql->user, $password);
             $pdoDB = new \PDO($connectionString, $this->mysql->user, $password);
             $pdoDB->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $pdoDB->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);

--- a/src/Joomlatools/Console/Command/Database/AbstractDatabase.php
+++ b/src/Joomlatools/Console/Command/Database/AbstractDatabase.php
@@ -117,9 +117,9 @@ abstract class AbstractDatabase extends AbstractSite
     {
         $db = $this->dbConnection();
         try {
-            $db->query($query);
+            $db->exec($query);
         } catch (\PDOException $ex) {
-            throw new \RuntimeException(sprintf('Database query failed: "%s"', $query));
+            throw new \RuntimeException(sprintf('Database query failed: error: "%s" "%s"',$ex->getMessage(), $query));
         }
     }
 

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -93,16 +93,14 @@ class Install extends AbstractDatabase
         $imports = $this->_getSQLFiles($input, $output);
 
         foreach ($imports as $import) {
-            foreach ($this->file_lines($import) as $line) {
-                if (strlen($line) < 2) {
-                    continue;
-                }
-                $line = str_replace('#__', 'j_', $line);
-                // throws Exception
-                var_dump($line);
-                $this->executeSQL($line);
+            $content = file_get_contents($import);
+            if (strlen($content) < 2) {
+                continue;
             }
-            
+            $content = str_replace('#__', 'j_', $content);
+            // throws Exception
+            $this->executeSQL($content);
+          
             if (!empty($result)) {
                 throw new \RuntimeException(sprintf('Cannot import database "%s". Error: %s', basename($import), $result));
             }

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -92,24 +92,23 @@ class Install extends AbstractDatabase
 
         $imports = $this->_getSQLFiles($input, $output);
 
-        foreach($imports as $import)
-        {
-            $tmp      = tempnam('/tmp', 'dump');
-            $contents = file_get_contents($import);
-            $contents = str_replace('#__', 'j_', $contents);
-
-            file_put_contents($tmp, $contents);
-
-            $password = empty($this->mysql->password) ? '' : sprintf("-p'%s'", $this->mysql->password);
-            $result = exec(sprintf("mysql --host=%s --port=%u --user='%s' %s %s < %s", $this->mysql->host, $this->mysql->port, $this->mysql->user, $password, $this->target_db, $tmp));
-
-            unlink($tmp);
-
+        foreach ($imports as $import) {
+            foreach ($this->file_lines($import) as $line) {
+                if (strlen($line) < 2) {
+                    continue;
+                }
+                $line = str_replace('#__', 'j_', $line);
+                // throws Exception
+                var_dump($line);
+                $this->executeSQL($line);
+            }
+            
             if (!empty($result)) {
                 throw new \RuntimeException(sprintf('Cannot import database "%s". Error: %s', basename($import), $result));
             }
         }
     }
+
 
     public function check(InputInterface $input, OutputInterface $output)
     {

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -108,17 +108,11 @@ class Install extends AbstractDatabase
             try {
                 $this->executeSQL($content);
             } catch (\Exception $exception) {
-                throw new \RuntimeException(
-                    sprintf(
-                        'Cannot import database file "%s". Error: %s',
-                        basename($import),
-                        $exception->getMessage()
-                    )
-                );
+                $message =  sprintf('Cannot import database file "%s". Error: %s', basename($import), $exception->getMessage());
+                throw new \RuntimeException($message);
             }
         }
     }
-
 
     public function check(InputInterface $input, OutputInterface $output)
     {

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -29,7 +29,7 @@ class Install extends Database\AbstractDatabase
     protected function configure()
     {
         parent::configure();
-
+            
         $this
             ->setName('site:install')
             ->setDescription('Install an existing Joomla codebase. Sets up configuration and installs the database.')
@@ -82,6 +82,7 @@ class Install extends Database\AbstractDatabase
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         parent::execute($input, $output);
+
 
         if ($input->getOption('interactive')) {
             $this->_promptDatabaseDetails($input, $output);

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -29,7 +29,6 @@ class Install extends Database\AbstractDatabase
     protected function configure()
     {
         parent::configure();
-            
         $this
             ->setName('site:install')
             ->setDescription('Install an existing Joomla codebase. Sets up configuration and installs the database.')
@@ -82,7 +81,6 @@ class Install extends Database\AbstractDatabase
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         parent::execute($input, $output);
-
 
         if ($input->getOption('interactive')) {
             $this->_promptDatabaseDetails($input, $output);


### PR DESCRIPTION
Replaced command line mysql to pdo. Not sure how to continue, but now the installer works without mysql binary client (we use docker).
