### PR TITLE
Configuration regex fixup

### DIFF
--- a/src/Joomlatools/Console/Command/Site/Configure.php
+++ b/src/Joomlatools/Console/Command/Site/Configure.php
@@ -135,20 +135,21 @@ class Configure extends AbstractDatabase
 
         $contents = file_get_contents($source);
         $replace  = function($name, $value, &$contents) {
-            $pattern = sprintf('#\$%s\s*=\s*(["\']).*?(?<!\\\\)\1#', $name);
+            $pattern = sprintf('#\$%s\s*=\s*(["\']?).*?\1(?=[;\1])#', $name);
             $match   = preg_match($pattern, $contents);
+            $value   = ctype_digit($value) ? $value : "'" . str_replace("'", "\\'", $value) . "'";
 
             if(!$match)
             {
-                $pattern 	 = "/^\s?(\})\s?$/m";
-                $replacement = sprintf("\tpublic \$%s = '%s';\n}", $name, $value);
+                $pattern 	 = "/^\s*}\s*$/m";
+                $replacement = sprintf("\tpublic \$%s = %s;\n}", $name, $value);
             }
-            else $replacement = sprintf("\$%s = '%s'", $name, $value);
+            else $replacement = sprintf("\$%s = %s", $name, $value);
 
             $contents = preg_replace($pattern, $replacement, $contents);
         };
         $remove   = function($name, &$contents) {
-            $pattern  = sprintf('#public\s+\$%s\s*=\s*(["\']).*?(?<!\\\\)\1#', $name);
+            $pattern  = sprintf('#public\s+\$%s\s*=\s*(["\']?).*?\1(?=[;\1])\s*;#', $name);
             $contents = preg_replace($pattern, '', $contents);
         };
 

--- a/src/Joomlatools/Console/Command/Site/Configure.php
+++ b/src/Joomlatools/Console/Command/Site/Configure.php
@@ -137,7 +137,7 @@ class Configure extends AbstractDatabase
         $replace  = function($name, $value, &$contents) {
             $pattern = sprintf('#\$%s\s*=\s*(["\']?).*?\1(?=[;\1])#', $name);
             $match   = preg_match($pattern, $contents);
-            $value   = ctype_digit($value) ? $value : "'" . str_replace("'", "\\'", $value) . "'";
+            $value   = is_numeric($value) ? $value : "'" . str_replace("'", "\\'", $value) . "'";
 
             if(!$match)
             {


### PR DESCRIPTION
Initial commit had some outstanding bugs,

Fixes: 
- Numeric values unmatched
- Treat numeric values as numeric rather than strings on replacement spec
- Cleanup semicolon on removal
- Allow single quotes in values, e.g. $sitename = "Spanky's House of Fun";

It's still possible to leave dangling comments that reside on the same line as the property as if you were to remove $log_path for whatever reason. Purely cosmetic and most of these installs I'd imagine are automated 100%.