### PR TITLE
Check PHP version before running command

### DIFF
--- a/bin/joomla
+++ b/bin/joomla
@@ -6,6 +6,11 @@
  * @link		http://github.com/joomlatools/joomlatools-console for the canonical source repository
  */
 
+if (version_compare(PHP_VERSION, '7.1.3', '<')) {
+	echo "This command requires at least PHP version 7.1.3 to run";
+	die();
+} 
+
 $dirs = explode(DIRECTORY_SEPARATOR, __DIR__);
 for ($i = count($dirs); $i >= 0; $i--)
 {

--- a/bin/joomla
+++ b/bin/joomla
@@ -6,9 +6,10 @@
  * @link		http://github.com/joomlatools/joomlatools-console for the canonical source repository
  */
 
-if (version_compare(PHP_VERSION, '7.1.3', '<')) {
-	echo "This command requires at least PHP version 7.1.3 to run";
-	die();
+if (version_compare(PHP_VERSION, '7.1.3', '<'))
+{
+	echo "This command requires at least PHP version 7.1.3 to run. Exiting.";
+	exit(1);
 } 
 
 $dirs = explode(DIRECTORY_SEPARATOR, __DIR__);


### PR DESCRIPTION
With the update to Symfony console 4.x it now can only run with PHP 7.1.3 and higher.  This can cause problems if you are using `box php:use` to work with different versions of PHP.  I added a quick check before accessing the console just so we get a nicer error message.