### PR TITLE
Added an option to use existent databases in site:install

### DIFF
--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -77,7 +77,7 @@ class Install extends AbstractDatabase
                 'Do not check if database already exists or not.'
             )
             ->addOption(
-                'use-existent-db',
+                'skip-create-statement',
                 null,
                 InputOption::VALUE_NONE,
                 'Use an already existent database'
@@ -93,7 +93,7 @@ class Install extends AbstractDatabase
 
         $this->drop        = $input->getOption('drop');
         $this->skip_check  = $input->getOption('skip-exists-check');
-        $this->existent_db = $input->getOption('use-existent-db');
+        $this->existent_db = $input->getOption('skip-create-statement');
 
         $this->check($input, $output);
 

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -157,6 +157,7 @@ class Install extends AbstractDatabase
 
     public function check(InputInterface $input, OutputInterface $output)
     {
+        echo "TARGET DIR ".$this->target_dir;
         if (!file_exists($this->target_dir)) {
             throw new \RuntimeException(sprintf('Site %s not found', $this->site));
         }

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -36,13 +36,12 @@ class Install extends AbstractDatabase
      */
     protected $skip_check = false;
 
-
     /**
      * Flag to use an already existent database
      *
      * @var boolean
      */
-    protected $existent_db = false;
+    protected $skip_create_statement = false;
 
     protected function configure()
     {
@@ -80,7 +79,7 @@ class Install extends AbstractDatabase
                 'skip-create-statement',
                 null,
                 InputOption::VALUE_NONE,
-                'Use an already existent database'
+                'Do not run the "CREATE IF NOT EXISTS <db>" query. Use this if the user does not have CREATE privileges on the database.'
             )
         ;
     }
@@ -91,9 +90,9 @@ class Install extends AbstractDatabase
 
         $password = empty($this->mysql->password) ? '' : sprintf("-p'%s'", $this->mysql->password);
 
-        $this->drop        = $input->getOption('drop');
-        $this->skip_check  = $input->getOption('skip-exists-check');
-        $this->existent_db = $input->getOption('skip-create-statement');
+        $this->drop                  = $input->getOption('drop');
+        $this->skip_check            = $input->getOption('skip-exists-check');
+        $this->skip_create_statement = $input->getOption('skip-create-statement');
 
         $this->check($input, $output);
 
@@ -101,13 +100,14 @@ class Install extends AbstractDatabase
             $this->_executeSQL(sprintf("DROP DATABASE IF EXISTS `%s`", $this->target_db));
         }
 
-        if (!$this->existent_db) {
+        if (!$this->skip_create_statement)
+        {
             $result = $this->_executeSQL(sprintf("CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8", $this->target_db));
+
             if (!empty($result)) {
                 throw new \RuntimeException(sprintf('Cannot create database %s. Error: %s', $this->target_db, $result));
             }
         }
-
 
         $imports = $this->_getSQLFiles($input, $output);
 
@@ -161,7 +161,7 @@ class Install extends AbstractDatabase
             throw new \RuntimeException(sprintf('Site %s not found', $this->site));
         }
 
-        if ($this->drop === false && !($this->skip_check === true || $this->existent_db === true ))
+        if ($this->drop === false && !($this->skip_check === true || $this->skip_create_statement === true ))
         {
             $result = $this->_executeSQL(sprintf("SHOW DATABASES LIKE \"%s\"", $this->target_db));
 

--- a/src/Joomlatools/Console/Command/Database/Install.php
+++ b/src/Joomlatools/Console/Command/Database/Install.php
@@ -157,7 +157,6 @@ class Install extends AbstractDatabase
 
     public function check(InputInterface $input, OutputInterface $output)
     {
-        echo "TARGET DIR ".$this->target_dir;
         if (!file_exists($this->target_dir)) {
             throw new \RuntimeException(sprintf('Site %s not found', $this->site));
         }

--- a/src/Joomlatools/Console/Command/Site/AbstractSite.php
+++ b/src/Joomlatools/Console/Command/Site/AbstractSite.php
@@ -41,6 +41,12 @@ abstract class AbstractSite extends Command
             "Web server root",
             '/var/www'
         )
+        ->addOption(
+            'use-webroot-dir',
+            null,
+            InputOption::VALUE_NONE,
+            "Uses directory specified with --www as the site install dir"
+         )
         ;
     }
 
@@ -48,7 +54,13 @@ abstract class AbstractSite extends Command
     {
         $this->site       = $input->getArgument('site');
         $this->www        = $input->getOption('www');
-        $this->target_dir = $this->www.'/'.$this->site;
+        echo "WR OPTION ".$input->getOption('use-webroot-dir');
+        if ($input->getOption('use-webroot-dir')) {
+            $this->target_dir = $this->www;
+        } else {
+            $this->target_dir = $this->www.'/'.$this->site;
+        }
+        echo "TARGET DIR ".$this->target_dir;
     }
 
     /**

--- a/src/Joomlatools/Console/Command/Site/AbstractSite.php
+++ b/src/Joomlatools/Console/Command/Site/AbstractSite.php
@@ -54,13 +54,11 @@ abstract class AbstractSite extends Command
     {
         $this->site       = $input->getArgument('site');
         $this->www        = $input->getOption('www');
-        echo "WR OPTION ".$input->getOption('use-webroot-dir');
         if ($input->getOption('use-webroot-dir')) {
             $this->target_dir = $this->www;
         } else {
             $this->target_dir = $this->www.'/'.$this->site;
         }
-        echo "TARGET DIR ".$this->target_dir;
     }
 
     /**

--- a/src/Joomlatools/Console/Command/Site/Create.php
+++ b/src/Joomlatools/Console/Command/Site/Create.php
@@ -146,6 +146,12 @@ EOF
                 InputOption::VALUE_OPTIONAL,
                 'Clone the Git repository instead of creating a copy in the target directory. Use --clone=shallow for a shallow clone or leave empty.',
                 true
+            )
+            ->addOption(
+                'skip-create-statement',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not run the "CREATE IF NOT EXISTS <db>" query. Use this if the user does not have CREATE privileges on the database.'
             );
     }
 
@@ -172,7 +178,7 @@ EOF
                 '--www'  => $this->www
             );
 
-            $optionalArgs = array('sample-data', 'symlink', 'projects-dir', 'interactive', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'options');
+            $optionalArgs = array('sample-data', 'symlink', 'projects-dir', 'interactive', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'options', 'skip-create-statement');
             foreach ($optionalArgs as $optionalArg)
             {
                 $value = $input->getOption($optionalArg);

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -77,7 +77,7 @@ class Install extends Database\AbstractDatabase
                 'Do not check if database already exists or not.'
             )
             ->addOption(
-                'use-existent-db',
+                'skip-create-statement',
                 null,
                 InputOption::VALUE_NONE,
                 'Use an already existent database'
@@ -136,7 +136,7 @@ class Install extends Database\AbstractDatabase
             '--www'  => $this->www
         );
 
-        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'skip-exists-check', 'use-existent-db', 'www', 'use-webroot-dir');
+        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'skip-exists-check', 'skip-create-statement', 'www', 'use-webroot-dir');
         foreach ($optionalArgs as $optionalArg)
         {
             $value = $input->getOption($optionalArg);

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -136,7 +136,7 @@ class Install extends Database\AbstractDatabase
             '--www'  => $this->www
         );
 
-        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'skip-exists-check', 'use-existent-db');
+        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'skip-exists-check', 'use-existent-db', 'www', 'use-webroot-dir');
         foreach ($optionalArgs as $optionalArg)
         {
             $value = $input->getOption($optionalArg);
@@ -161,7 +161,7 @@ class Install extends Database\AbstractDatabase
             '--www'  => $this->www
         );
 
-        $optionalArgs = array('overwrite', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'mysql-driver', 'interactive', 'options');
+        $optionalArgs = array('overwrite', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'mysql-driver', 'interactive', 'options', 'www', 'use-webroot-dir');
         foreach ($optionalArgs as $optionalArg)
         {
             $value = $input->getOption($optionalArg);

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -77,6 +77,12 @@ class Install extends Database\AbstractDatabase
                 'Do not check if database already exists or not.'
             )
             ->addOption(
+                'use-existent-db',
+                null,
+                InputOption::VALUE_NONE,
+                'Use an already existent database'
+            )
+            ->addOption(
                 'options',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -130,7 +136,7 @@ class Install extends Database\AbstractDatabase
             '--www'  => $this->www
         );
 
-        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database');
+        $optionalArgs = array('sample-data', 'drop', 'mysql-login', 'mysql_db_prefix', 'mysql-db-prefix', 'mysql-host', 'mysql-port', 'mysql-database', 'skip-exists-check', 'use-existent-db');
         foreach ($optionalArgs as $optionalArg)
         {
             $value = $input->getOption($optionalArg);

--- a/src/Joomlatools/Console/Command/Site/Install.php
+++ b/src/Joomlatools/Console/Command/Site/Install.php
@@ -80,7 +80,7 @@ class Install extends Database\AbstractDatabase
                 'skip-create-statement',
                 null,
                 InputOption::VALUE_NONE,
-                'Use an already existent database'
+                'Do not run the "CREATE IF NOT EXISTS <db>" query. Use this if the user does not have CREATE privileges on the database.'
             )
             ->addOption(
                 'options',


### PR DESCRIPTION
Hi,
I added a --use-existent-db option in site:install so that it's possible to use already existent databases without creating new one. 
This is useful when you don't want to give Joomla database user root permissions or the like (also usually, on hosting platforms you're not allowed to create users or databases).
