### PR TITLE
Prevent 'Incorrect datetime value' MySQL error

### DIFF
--- a/bin/.files/joomla2.users.sql
+++ b/bin/.files/joomla2.users.sql
@@ -1,8 +1,8 @@
 INSERT INTO `j_users` (`id`, `name`, `username`, `email`, `password`, `block`, `sendEmail`, `registerDate`, `lastvisitDate`, `activation`, `params`, `lastResetTime`, `resetCount`)
 VALUES
-	(970, 'Super User', 'admin', 'admin@example.com', 'e8d876703ae04a3fe6c4868ff296fb9f:99SknoS4CFHGWhkOtk8cNTIDXR0bSUvN', 0, 1, '2013-07-24 11:23:33', '2013-07-26 13:40:55', '0', '', '0000-00-00 00:00:00', 0),
-	(971, 'User', 'user', 'user@example.com', '92b46d92fc58eb86e92a8c796febeb34:fXySsDEWvyiIg0ifkftgTkrXzmviMvC3', 0, 0, '2013-07-24 11:28:07', '0000-00-00 00:00:00', '', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', '0000-00-00 00:00:00', 0),
-	(972, 'Manager', 'manager', 'manager@example.com', '770b271ae81867018860e471d51781c9:8CqzT83QhW5AJACYBqDqoHJJE21l8r8Y', 0, 0, '2013-07-24 11:28:20', '0000-00-00 00:00:00', '', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', '0000-00-00 00:00:00', 0);
+	(970, 'Super User', 'admin', 'admin@example.com', 'e8d876703ae04a3fe6c4868ff296fb9f:99SknoS4CFHGWhkOtk8cNTIDXR0bSUvN', 0, 1, NOW(), NOW(), '0', '', NOW(), 0),
+	(971, 'User', 'user', 'user@example.com', '92b46d92fc58eb86e92a8c796febeb34:fXySsDEWvyiIg0ifkftgTkrXzmviMvC3', 0, 0, NOW(), NOW(), '', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', NOW(), 0),
+	(972, 'Manager', 'manager', 'manager@example.com', '770b271ae81867018860e471d51781c9:8CqzT83QhW5AJACYBqDqoHJJE21l8r8Y', 0, 0, NOW(), NOW(), '', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', NOW(), 0);
 
 INSERT INTO `j_user_usergroup_map` (`user_id`, `group_id`)
 VALUES

--- a/bin/.files/joomla3.users.sql
+++ b/bin/.files/joomla3.users.sql
@@ -1,8 +1,8 @@
 INSERT INTO `j_users` (`id`, `name`, `username`, `email`, `password`, `block`, `sendEmail`, `registerDate`, `lastvisitDate`, `activation`, `params`, `lastResetTime`, `resetCount`)
 VALUES
-	(951, 'Super User', 'admin', 'admin@example.com', '871b1a6d54b378b5547a945ea1a8bd18:3UgsAngDFq7D0FRmyiWey4qgV8n5PpEJ', 0, 1, '2013-07-24 09:07:43', '2014-01-07 11:18:12', '0', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', '0000-00-00 00:00:00', 0),
-	(952, 'User', 'user', 'user@example.com', '931d334de664be1135bed97fd9bb7b62:ZzvicSTnh9dr1Ln36G3MgkC9WSa9J4PW', 0, 0, '2013-07-24 09:23:03', '0000-00-00 00:00:00', '', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', '0000-00-00 00:00:00', 0),
-	(953, 'Manager', 'manager', 'manager@example.com', 'e0f025cc620a663e172c8b25911e5c4e:44wqdHQWhDPcrRg5koGsWJ9Zlhr9WC5x', 0, 0, '2013-07-24 10:53:59', '0000-00-00 00:00:00', '', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', '0000-00-00 00:00:00', 0);
+	(951, 'Super User', 'admin', 'admin@example.com', '871b1a6d54b378b5547a945ea1a8bd18:3UgsAngDFq7D0FRmyiWey4qgV8n5PpEJ', 0, 1, NOW(), NOW(), '0', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', NOW(), 0),
+	(952, 'User', 'user', 'user@example.com', '931d334de664be1135bed97fd9bb7b62:ZzvicSTnh9dr1Ln36G3MgkC9WSa9J4PW', 0, 0, NOW(), NOW(), '', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', NOW(), 0),
+	(953, 'Manager', 'manager', 'manager@example.com', 'e0f025cc620a663e172c8b25911e5c4e:44wqdHQWhDPcrRg5koGsWJ9Zlhr9WC5x', 0, 0, NOW(), NOW(), '', '{\"admin_style\":\"\",\"admin_language\":\"\",\"language\":\"\",\"editor\":\"\",\"helpsite\":\"\",\"timezone\":\"\"}', NOW(), 0);
 
 INSERT INTO `j_user_usergroup_map` (`user_id`, `group_id`)
 VALUES


### PR DESCRIPTION
I experienced the following error when running `site:install` with `MySQL 5.7`:

```shell
ERROR 1292 (22007) at line 1: Incorrect datetime value: '0000-00-00 00:00:00' for column 'lastResetTime' at row 1
```

- `MySQL 5.6` doesn't have this issue.
- Using `NOW()` resolves this issue.

>Read more about [SQL Mode Changes in MySQL 5.7](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-changes) and [NO_ZERO_IN_DATE](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date)
