### PR TITLE
Allow target directory to exist if it is empty

### DIFF
--- a/src/Joomlatools/Console/Command/Site/Create.php
+++ b/src/Joomlatools/Console/Command/Site/Create.php
@@ -195,8 +195,12 @@ EOF
 
     public function check(InputInterface $input, OutputInterface $output)
     {
-        if (file_exists($this->target_dir) && count(scandir($this->target_dir)) > 2) {
+        if (file_exists($this->target_dir) && !is_dir($this->target_dir)) {
             throw new \RuntimeException(sprintf('A site with name %s already exists', $this->site));
+        }
+
+        if (is_dir($this->target_dir) && count(scandir($this->target_dir)) > 2) {
+            throw new \RuntimeException(sprintf('Site directory \'%s\' is not empty.', $this->target_dir));
         }
     }
 

--- a/src/Joomlatools/Console/Command/Site/Create.php
+++ b/src/Joomlatools/Console/Command/Site/Create.php
@@ -195,7 +195,7 @@ EOF
 
     public function check(InputInterface $input, OutputInterface $output)
     {
-        if (file_exists($this->target_dir)) {
+        if (file_exists($this->target_dir) && count(scandir($this->target_dir)) > 2) {
             throw new \RuntimeException(sprintf('A site with name %s already exists', $this->site));
         }
     }

--- a/src/Joomlatools/Console/Command/Site/Create.php
+++ b/src/Joomlatools/Console/Command/Site/Create.php
@@ -196,11 +196,11 @@ EOF
     public function check(InputInterface $input, OutputInterface $output)
     {
         if (file_exists($this->target_dir) && !is_dir($this->target_dir)) {
-            throw new \RuntimeException(sprintf('A site with name %s already exists', $this->site));
+            throw new \RuntimeException(sprintf('A file named \'%s\' already exists', $this->site));
         }
 
         if (is_dir($this->target_dir) && count(scandir($this->target_dir)) > 2) {
-            throw new \RuntimeException(sprintf('Site directory \'%s\' is not empty.', $this->target_dir));
+            throw new \RuntimeException(sprintf('Site directory \'%s\' is not empty.', $this->site));
         }
     }
 

--- a/src/Joomlatools/Console/Command/Site/Delete.php
+++ b/src/Joomlatools/Console/Command/Site/Delete.php
@@ -55,7 +55,7 @@ class Delete extends Database\AbstractDatabase
             throw new \RuntimeException('You are currently in the directory you are trying to delete. Aborting');
         }
 
-        if (!file_exists($this->target_dir)) {
+        if (!is_dir($this->target_dir)) {
             throw new \RuntimeException(sprintf('The site %s does not exist!', $this->site));
         }
     }


### PR DESCRIPTION
Alter the site existence check for the site:create command to allow the
target directory to exist as long as it is empty.

This is useful when the user is manually managing their virtual hosts,
as they won't have to delete their webroot directory when using
--use-webroot-dir.

The count has to be above 2 because scandir includes `.` and `..`.
Another, more verbose, way to go about it would be 
`count(array_diff(scandir($this->target_directory), ['.', '..'])) > 0)`
Feel free to change it if you prefer that approach.