### PR TITLE
Fix bug of joomla versions subcommand

### DIFF
--- a/src/Joomlatools/Console/Command/Versions.php
+++ b/src/Joomlatools/Console/Command/Versions.php
@@ -92,6 +92,7 @@ class Versions extends Command
                 ->setStyle('compact')
                 ->render($output);
         }
+        return 0;
     }
 
     public function setRepository($repository)


### PR DESCRIPTION
This pull request is a minor bug fix of what arise when typing joomla versions subcommand.
Expected:
Show a list of all available Joomla! versions in joomla-cms repo without errors or exception showing.
Actual:
It shows a list of all available Joomla! versions but with an Exception at the end which is
  
[fix-console-versions-bug-php-deprecated-exception-stack-trace.txt](https://github.com/joomlatools/joomlatools-console/files/4533934/fix-console-versions-bug-php-deprecated-exception-stack-trace.txt)
