### PR TITLE
Fix namespace typo causing autoloader error in composer v2.x 

### DIFF
--- a/src/Joomlatools/Console/Command/Site/CheckIn.php
+++ b/src/Joomlatools/Console/Command/Site/CheckIn.php
@@ -5,7 +5,7 @@
  * @link		http://github.com/joomlatools/joomlatools-console for the canonical source repository
  */
 
-namespace Joomlatools\Console\Command\SIte;
+namespace Joomlatools\Console\Command\Site;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
This pull request is a typo fix in a namespace that was preventing composer v2.x (I have composer 2.0.14) from autoloading when doing a

composer global update

to update joomlatools/console composer package.
With this fix there is no more errors showing.
Please review my code and merge it if you think it's valuable.

Thanks for your time and patience joomlatools team.