### PR TITLE
Fix php level

### DIFF
--- a/src/Joomlatools/Console/Command/Configurable.php
+++ b/src/Joomlatools/Console/Command/Configurable.php
@@ -19,7 +19,7 @@ class Configurable extends Command
     public function addArgument($name, $mode = null, $description = '', $default = null)
     {
         if ($mode != InputOption::VALUE_NONE) {
-            $default = $this->_getConfigOverride($name) ?? $default;
+            $default = $this->_getConfigOverride($name) === null ? $default : $this->_getConfigOverride($name);
         }
 
         return parent::addArgument($name, $mode, $description, $default);
@@ -28,7 +28,7 @@ class Configurable extends Command
     public function addOption($name, $shortcut = null, $mode = null, $description = '', $default = null)
     {
         if ($mode != InputOption::VALUE_NONE) {
-            $default = $this->_getConfigOverride($name) ?? $default;
+            $default = $this->_getConfigOverride($name) === null ? $default : $this->_getConfigOverride($name);
         }
 
         return parent::addOption($name, $shortcut, $mode, $description, $default);

--- a/src/Joomlatools/Console/Command/Extension/Install.php
+++ b/src/Joomlatools/Console/Command/Extension/Install.php
@@ -130,7 +130,7 @@ EOL
 
             if (isset($results['plg_system_joomlatools']) && (\in_array('all', $this->extensions) || \in_array('joomlatools-framework', $this->extensions))) {
                 $result = Util::executeJ4CliCommand($this->target_dir, "extension:discover:install $verbosity --eid={$results['plg_system_joomlatools']}");
-                
+
                 unset($results['plg_system_joomlatools']);
 
                 $output->writeln("<info>Joomlatools Framework install: $result</info>\n");
@@ -138,12 +138,12 @@ EOL
 
             foreach ($results as $extension => $extension_id) {
                 if (\in_array('all', $this->extensions) || \in_array(substr($extension, 4), $this->extensions) || \in_array($extension, $this->extensions)) {
-                    $result = Util::executeJ4CliCommand($this->target_dir, "extension:discover:install $verbosity --eid=$extension_id", );
+                    $result = Util::executeJ4CliCommand($this->target_dir, "extension:discover:install $verbosity --eid=$extension_id");
 
                     $output->writeln("<info>$result</info>\n");
                 }
             }
-            
+
             return;
         }
 

--- a/src/Joomlatools/Console/Joomla/Util.php
+++ b/src/Joomlatools/Console/Joomla/Util.php
@@ -11,7 +11,11 @@ class Util
 {
     protected static $_versions  = array();
 
-    public static function executeCommand(string $command): string
+    /**
+     * @param string $command
+     * @return string
+     */
+    public static function executeCommand($command)
     {
         exec($command, $output, $code);
         if (count($output) === 0) {
@@ -31,12 +35,21 @@ class Util
         return implode(PHP_EOL, $output);
     }
 
-    public static function isJoomla4($base): bool
+    /**
+     * @param string $base
+     * @return bool
+     */
+    public static function isJoomla4($base)
     {
          return (bool) \version_compare(static::getJoomlaVersion($base)->release, '4.0.0', '>=');
     }
 
-    public static function executeJ4CliCommand($base, $command): string
+    /**
+     * @param string $base
+     * @param string $command
+     * @return string
+     */
+    public static function executeJ4CliCommand($base, $command)
     {
         return static::executeCommand("php $base/cli/joomla.php $command");
     }
@@ -125,13 +138,13 @@ class Util
             }
             else self::$_versions[$key] = false;
         }
-        
+
         return self::$_versions[$key];
     }
 
     /**
      * Builds the full path for a given path inside a Joomla project.
-     * 
+     *
      * @param string $path The original relative path to the file/directory
      * @param string $base The root directory of the Joomla installation
      * @return string Target path


### PR DESCRIPTION
In composer.json, the required php level is 5.6 or higher.
This PR fixes syntax that is not available in 5.6.