### PR TITLE
Fix mv command, if target_dir contains & character

### DIFF
--- a/src/Joomlatools/Console/Command/Site/Configure.php
+++ b/src/Joomlatools/Console/Command/Site/Configure.php
@@ -192,7 +192,7 @@ class Configure extends AbstractDatabase
         chmod($target, 0664);
 
         if (file_exists($this->target_dir.'/installation')) {
-            `mv $this->target_dir/installation $this->target_dir/_installation`;
+            `mv "$this->target_dir/installation" "$this->target_dir/_installation"`;
         }
     }
 


### PR DESCRIPTION
The `mv` will break, if the target_dir contains an `&` character. Quoting the paths fixes the issue.